### PR TITLE
feat: add support for uppercase 'D' flag in CLI options

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -23,6 +23,7 @@ cli
     _: string[]
     dev: boolean
     d: boolean
+    D: boolean
     workspace: boolean
     w: boolean
     catalog: string | boolean
@@ -226,7 +227,7 @@ cli
       }
     }
 
-    const isDev = options.dev || options.d
+    const isDev = options.dev || options.d || options.D
 
     for (const pkg of parsed) {
       if (pkg.catalog)


### PR DESCRIPTION
Adds support for `-D` as an alias for `-d` (--dev) in the CLI, fixing the issue where uppercase `D` was not recognized

 [feat: Support devDependencies install #7](https://github.com/antfu/nip/issues/7)